### PR TITLE
fixed bug with matching cluster name to list of nodes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from os import environ
 
 setup(name="vlab-cli",
       author="Nicholas Willhite",
-      version='0.0.2',
+      version='0.0.3',
       packages=find_packages(),
       classifiers=[
         'Development Status :: 3 - Alpha',

--- a/vlab_cli/subcommands/delete/onefs.py
+++ b/vlab_cli/subcommands/delete/onefs.py
@@ -40,7 +40,7 @@ def delete_cluster(vlab_api, cluster):
                         endpoint='/api/1/inf/onefs',
                         message='Looking up OneFS cluster {}'.format(cluster),
                         method='GET').json()
-    nodes = _find_cluster_nodes(cluster, all_nodes=data['content'].keys()]
+    nodes = _find_cluster_nodes(cluster, all_nodes=data['content'].keys())
     if not nodes:
         raise click.ClickException('No cluster named {} found'.format(cluster))
     tasks = {}

--- a/vlab_cli/subcommands/delete/onefs.py
+++ b/vlab_cli/subcommands/delete/onefs.py
@@ -40,7 +40,7 @@ def delete_cluster(vlab_api, cluster):
                         endpoint='/api/1/inf/onefs',
                         message='Looking up OneFS cluster {}'.format(cluster),
                         method='GET').json()
-    nodes = [x for x in data['content'].keys() if x.split('-')[0] == cluster]
+    nodes = _find_cluster_nodes(cluster, all_nodes=data['content'].keys()]
     if not nodes:
         raise click.ClickException('No cluster named {} found'.format(cluster))
     tasks = {}
@@ -51,3 +51,37 @@ def delete_cluster(vlab_api, cluster):
             tasks[node] = '/api/1/inf/onefs/task/{}'.format(resp.json()['content']['task-id'])
         block_on_tasks(vlab_api, tasks)
     click.echo('OK!')
+
+
+def _find_cluster_nodes(cluster_name, all_nodes):
+    """Given a cluster name, and a list of nodes owned, find the nodes that belong
+    to that cluster
+
+    :Returns: List
+
+    :param cluster_name: The name of the OneFS cluster
+    :type cluster_name: String
+
+    :param all_nodes: Every OneFS node a user owns
+    :type all_nodes: List
+    """
+    # Example of nodes in the cluster named "foo-bar"
+    # foo-bar-1
+    # foo-bar-10
+    # foo-bar-100
+    # Example of nodes in a different cluster
+    # foo-barb-1
+    # foo-bar
+    # foobar
+    # Must not falsely match foo-bar-baz-1, foobar, or foo-bar
+    cluster_nodes = []
+    cluster_name_has_dashes = bool(cluster_name.count('-'))
+    for node in all_nodes:
+        # perform 1 split at most
+        chunked_name = node.rsplit('-', 1)
+        # Avoid matching foo-bar the cluster with a single node named foo-bar
+        if cluster_name_has_dashes and len(chunked_name) == 1:
+            continue
+        elif chunked_name[0] == cluster_name:
+            cluster_nodes.append(node)
+    return cluster_nodes


### PR DESCRIPTION
A beta user was nice enough to find this bug! Basically, the CLI didn't account for a cluster's name having a `-` in it when running `vlab delete onefs --cluster <name>`. Now it _mega handles_ that situation.

Here's what the bug looks like in context of the CLI:
```
root@centos6 ~]# vlab delete onefs --cluster jv-8007
Looking up OneFS cluster jv-8007
Error: No cluster named jv-8007 found

[root@centos6 ~]# vlab show onefs
Collecting information about your OneFS nodes
 Name        | IPs   | Type   | Version   | Console
-------------+-------+--------+-----------+-----------------------------------------------------------------------
 jv-8007-1   |       | OneFS  | 8.0.0.7   | https://vlab-dev.igs.corp/api/1/link/9928a3e9bd25f37137c32410782fdfd8
 jv-8007-2   |       | OneFS  | 8.0.0.7   | https://vlab-dev.igs.corp/api/1/link/92ccaae37ca1727006e6b210f3b1f962
 jv-8007-3   |       | OneFS  | 8.0.0.7   | https://vlab-dev.igs.corp/api/1/link/69b42db9bb8fb1aad6cfcb672034d9c3
 vlab-test-1 |       | OneFS  | 8.1.2.0   | https://vlab-dev.igs.corp/api/1/link/3f0f4fe657c149d2d4c1e647b7a60341
```