### PR TITLE
Added default values to simplify command syntax for users

### DIFF
--- a/vlab_cli/subcommands/create/cee.py
+++ b/vlab_cli/subcommands/create/cee.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='8.5.1', show_default=True,
               help='The version of CEE to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the CEE instance in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new CEE instance to')
 @click.pass_context
 def cee(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/centos.py
+++ b/vlab_cli/subcommands/create/centos.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='7', show_default=True,
               help='The version of CentOS to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the CentOS instance in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new CentOS instance to')
 @click.pass_context
 def centos(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/claritynow.py
+++ b/vlab_cli/subcommands/create/claritynow.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='2.11.0', show_default=True,
               help='The version of ClarityNow to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the ClarityNow instance in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new ClarityNow instance to')
 @click.pass_context
 def claritynow(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/ecs.py
+++ b/vlab_cli/subcommands/create/ecs.py
@@ -12,7 +12,7 @@ from vlab_cli.lib.ascii_output import format_machine_info
               help='The version of ECS to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the ECS instance in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new ECS instance to')
 @click.pass_context
 def ecs(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/esrs.py
+++ b/vlab_cli/subcommands/create/esrs.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='3.28', show_default=True,
               help='The version of ESRS to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the ESRS instance in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new ESRS instance to')
 @click.pass_context
 def esrs(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/icap.py
+++ b/vlab_cli/subcommands/create/icap.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='1.0.0', show_default=True,
               help='The ICAP server version to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the ICAP server in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new ICAP server to')
 @click.pass_context
 def icap(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/iiq.py
+++ b/vlab_cli/subcommands/create/iiq.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='4.1.2', show_default=True,
               help='The version of InsightIQ to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the InsightIQ instance in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new IIQ instance to')
 @click.pass_context
 def iiq(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/router.py
+++ b/vlab_cli/subcommands/create/router.py
@@ -8,7 +8,7 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', default='1.1.8',
+@click.option('-i', '--image', default='1.1.8', show_default=True,
               help='The specific type & version of router to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name to give your new router')

--- a/vlab_cli/subcommands/create/windows.py
+++ b/vlab_cli/subcommands/create/windows.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='10', show_default=True,
               help='The version of Windows to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the Windows client in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new Windows client to')
 @click.pass_context
 def windows(ctx, name, image, external_network):

--- a/vlab_cli/subcommands/create/winserver.py
+++ b/vlab_cli/subcommands/create/winserver.py
@@ -8,11 +8,11 @@ from vlab_cli.lib.ascii_output import format_machine_info
 
 
 @click.command()
-@click.option('-i', '--image', cls=MandatoryOption,
+@click.option('-i', '--image', default='2012R2', show_default=True, 
               help='The version of Microsoft Server to create')
 @click.option('-n', '--name', cls=MandatoryOption,
               help='The name of the Microsoft Server in your lab')
-@click.option('-e', '--external-network', default='frontend',
+@click.option('-e', '--external-network', default='frontend', show_default=True,
               help='The public network to connect the new Microsoft Server to')
 @click.pass_context
 def winserver(ctx, name, image, external_network):


### PR DESCRIPTION
Most of the defaults added are for the versions to deploy. For instance, InsightIQ now defaults to deploying the recommended version. Also updated the `--help` output to note the defaults. I image simply seeing _what version is the default_ will also help users _guess and get it right_ for things like Windows Server.