### PR TITLE
CLI can make port mapping rules

### DIFF
--- a/vlab_cli/lib/api.py
+++ b/vlab_cli/lib/api.py
@@ -54,6 +54,7 @@ class vLabApi(object):
     :type log: logging.Logger
     """
     def __init__(self, server, token, verify=False, log=None):
+        self._ipam_ip = None
         self._server = server
         self._session = requests.Session()
         self._header = {'X-Auth': token,
@@ -176,6 +177,65 @@ class vLabApi(object):
         :type **kwargs: Dictionary
         """
         return self._call(method='delete', endpoint=endpoint, auto_check=auto_check, **kwargs)
+
+    def map_port(self, target_addr, target_port, target_name, target_component):
+        """Create a port mapping rule in the IPAM server
+
+        :Returns: None
+
+        :Raises: requests.HTTPError
+
+        :param target_addr: The IP address of the VM to create a mapping rule for
+        :type target_addr: String
+
+        :param target_port: The network port on the VM to create the mapping rule to
+        :type target_port: Integer
+
+        :param target_name: The name of the VM
+        :type target_name: String
+
+        :param target_component: The type of VM, i.e OneFS, InsightIQ, etc
+        :type target_component: String
+        """
+        if self._ipam_ip is None:
+            self._ipam_ip = self._find_ipam()
+        url = 'https://{}/api/1/ipam/portmap'.format(self._ipam_ip)
+        payload = {'target_addr' : target_addr,
+                   'target_port' : target_port,
+                   'target_name' : target_name,
+                   'target_component' : target_component}
+        resp = self.post(url, json=payload, auto_check=False)
+        resp.raise_for_status()
+
+
+    def _find_ipam(self):
+        """Discovers the IP of the IPAM server"""
+        resp1 = self.get(endpoint='/api/2/inf/gateway', auto_check=False)
+        status_url = resp1.links['status']['url']
+        for _ in range(0, 300, 1):
+            resp2 = self.get(status_url, auto_check=False)
+            if resp2.status_code == 202:
+                time.sleep(1)
+            else:
+                break
+        else:
+            error = 'Timed out trying to discovery Gateway IP'.format(task)
+            raise RuntimeError(error)
+        all_ips = resp2.json()['content']['ips']
+        ips = []
+        for ip in all_ips:
+            if ':' in ip:
+                continue
+            elif ip.startswith('127'):
+                continue
+            elif ip.startswith('192.168.'):
+                continue
+            else:
+                ips.append(ip)
+        if len(ips) != 1:
+            error = "Unexpected IP(s) found on gateway: {}".format(ips)
+            raise RuntimeError(error)
+        return ips[0]
 
 
 def build_url(base, *args):

--- a/vlab_cli/lib/click_extras.py
+++ b/vlab_cli/lib/click_extras.py
@@ -2,7 +2,7 @@
 """
 This module provides additional functionality for the click library
 """
-from click import command, option, Option, UsageError
+from click import command, option, Option, UsageError, ClickException
 
 
 class MutuallyExclusiveOption(Option):
@@ -74,3 +74,32 @@ class GlobalContext(object):
 
     def __delattr__(self, attr):
         raise AttributeError("can't set attribute")
+
+
+def get_portmap_ip(ips, ip_address):
+    """Determines which (if any) IP address to use in a port mapping rule.
+
+    :Returns: String
+
+    :Raises: click.ClickException
+
+    :param ips: The IPs owned/assigned to the VM
+    :type ips: List
+
+    :param ip_address: An explicit IP to use, supplied by the user, or None
+    :type ip_address: Enum(None, String)
+    """
+    if not (ip_address is None):
+        if not ip_address in ips:
+            error = 'Supplied IP is not owned by VM. VM has {}'.format(ips)
+            raise ClickException(error)
+        else:
+            return ip_address
+    elif len(ips) == 1:
+        return ips[0]
+    elif len(ips) > 1:
+        error = 'Must supply `--ip-address` when VM has mutiple IPs. Found: {}'.format(ips)
+        raise ClickException(error)
+    else:
+        error = "VM has no IPs. Unable to map a port"
+        raise ClickException(error)

--- a/vlab_cli/subcommands/__init__.py
+++ b/vlab_cli/subcommands/__init__.py
@@ -7,3 +7,4 @@ from vlab_cli.subcommands.delete import delete
 from vlab_cli.subcommands.show import show
 from vlab_cli.subcommands.power import power
 from vlab_cli.subcommands.connect import connect
+from vlab_cli.subcommands.portmap import portmap

--- a/vlab_cli/subcommands/create/gateway.py
+++ b/vlab_cli/subcommands/create/gateway.py
@@ -7,8 +7,10 @@ from vlab_cli.lib.api import consume_task
 
 
 @click.command()
-@click.option('-w', '--wan', default='WAN-DHCP', help='The name of the public network')
-@click.option('-l', '--lan', default='frontend', help='The name of the private network')
+@click.option('-w', '--wan', default='WAN-DHCP', show_default=True,
+              help='The name of the public network')
+@click.option('-l', '--lan', default='frontend', show_default=True,
+              help='The name of the private network')
 @click.pass_context
 def gateway(ctx, wan, lan):
     """Create a network gateway to your virtual lab"""
@@ -16,7 +18,7 @@ def gateway(ctx, wan, lan):
     click.secho('**NOTE**: Gateways can take 10-15 minutes to be created', bold=True)
     body = {'wan': wan, 'lan': '{}_{}'.format(ctx.obj.username, lan)}
     resp = consume_task(ctx.obj.vlab_api,
-                        endpoint='/api/1/inf/gateway',
+                        endpoint='/api/2/inf/gateway',
                         message='Creating a new default gateway',
                         body=body,
                         timeout=900,

--- a/vlab_cli/subcommands/delete/gateway.py
+++ b/vlab_cli/subcommands/delete/gateway.py
@@ -10,7 +10,7 @@ from vlab_cli.lib.api import consume_task
 def gateway(ctx):
     """Delete your network gateway"""
     consume_task(ctx.obj.vlab_api,
-                 endpoint='/api/1/inf/gateway',
+                 endpoint='/api/2/inf/gateway',
                  message='Deleting your gateway',
                  method='DELETE')
     click.echo('OK!')

--- a/vlab_cli/subcommands/portmap/__init__.py
+++ b/vlab_cli/subcommands/portmap/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: UTF-8 -*-
+from .base import portmap

--- a/vlab_cli/subcommands/portmap/base.py
+++ b/vlab_cli/subcommands/portmap/base.py
@@ -1,0 +1,37 @@
+# -*- coding: UTF-8 -*-
+"""
+Defines the CLI so users (if needed) can manually create port mapping/forwarding
+rules.
+"""
+import click
+
+from vlab_cli.subcommands.portmap.cee import cee
+from vlab_cli.subcommands.portmap.centos import centos
+from vlab_cli.subcommands.portmap.claritynow import claritynow
+from vlab_cli.subcommands.portmap.ecs import ecs
+from vlab_cli.subcommands.portmap.esrs import esrs
+from vlab_cli.subcommands.portmap.icap import icap
+from vlab_cli.subcommands.portmap.iiq import iiq
+from vlab_cli.subcommands.portmap.onefs import onefs
+from vlab_cli.subcommands.portmap.router import router
+from vlab_cli.subcommands.portmap.windows import windows
+from vlab_cli.subcommands.portmap.winserver import winserver
+
+
+@click.group()
+@click.pass_context
+def portmap(ctx):
+    """Manually create a port mapping/forwarding rule"""
+    pass
+
+
+portmap.add_command(cee)
+portmap.add_command(centos)
+portmap.add_command(claritynow)
+portmap.add_command(ecs)
+portmap.add_command(icap)
+portmap.add_command(iiq)
+portmap.add_command(onefs)
+portmap.add_command(router)
+portmap.add_command(windows)
+portmap.add_command(winserver)

--- a/vlab_cli/subcommands/portmap/cee.py
+++ b/vlab_cli/subcommands/portmap/cee.py
@@ -1,0 +1,45 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to EMC Common Event Enabler"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the EMC CEE instance')
+@click.option('-p', '--protocol', type=click.Choice(['ssh']),
+              default='ssh', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the EMC CEE instance to create a rule for')
+@click.pass_context
+def cee(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to an EMC Common Event Enabler instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/cee',
+                        message='Collecting information about your EMC CEE instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No CEE instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ip,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/centos.py
+++ b/vlab_cli/subcommands/portmap/centos.py
@@ -1,0 +1,45 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to CentOS"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the CentOS instance')
+@click.option('-p', '--protocol', type=click.Choice(['ssh']),
+              default='ssh', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the CentOS instance to create a rule for')
+@click.pass_context
+def centos(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to a CentOS instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/centos',
+                        message='Collecting information about your CentOS instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No CentOS instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ip,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/claritynow.py
+++ b/vlab_cli/subcommands/portmap/claritynow.py
@@ -1,0 +1,48 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to ClarityNow"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the ClarityNow instance')
+@click.option('-p', '--protocol', type=click.Choice(['ssh', 'rdp']),
+              default='ssh', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the ClarityNow instance to create a rule for')
+@click.pass_context
+def claritynow(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to a ClarityNow instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/claritynow',
+                        message='Collecting information about your ClarityNow instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No ClarityNow instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    if protocol == 'ssh':
+        port_number = 22
+    else:
+        port_number = 3389
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ip,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/ecs.py
+++ b/vlab_cli/subcommands/portmap/ecs.py
@@ -1,0 +1,48 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to EMC ECS"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the EMC ECS instance')
+@click.option('-p', '--protocol', type=click.Choice(['ssh', 'https']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the EMC ECS instance to create a rule for')
+@click.pass_context
+def ecs(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to an EMC ECS instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/ecs',
+                        message='Collecting information about your EMC ECS instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No EMC ECS instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    if protocol == 'https':
+        port_number = 443
+    else:
+        port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ips,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/esrs.py
+++ b/vlab_cli/subcommands/portmap/esrs.py
@@ -1,0 +1,48 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to EMC ESRS"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the EMC ESRS instance')
+@click.option('-p', '--protocol', type=click.Choice(['ssh', 'https']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the EMC ESRS instance to create a rule for')
+@click.pass_context
+def esrs(ctx, name, protocol):
+    """Create a port mapping rule to an EMC ESRS instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/esrs',
+                        message='Collecting information about your EMC ECS instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No EMC ECS instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    if protocol == 'https':
+        port_number = 443
+    else:
+        port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ips,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/icap.py
+++ b/vlab_cli/subcommands/portmap/icap.py
@@ -1,0 +1,46 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to ICAP Antivirus server"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the ICAP server')
+@click.option('-p', '--protocol', type=click.Choice(['rdp']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the ICAP sever to create a rule for')
+@click.pass_context
+def icap(ctx, name, protocol):
+    """Create a port mapping rule to an ICAP Antivirus server"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/icap',
+                        message='Collecting information about your ICAP servers',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No EMC ECS instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    port_number = 3389
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ips,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/iiq.py
+++ b/vlab_cli/subcommands/portmap/iiq.py
@@ -1,0 +1,48 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to InsightIQ"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the InsightIQ instance')
+@click.option('-p', '--protocol', type=click.Choice(['ssh', 'https']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the InsightIQ instance to create a rule for')
+@click.pass_context
+def iiq(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to an InsightIQ instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/insightiq',
+                        message='Collecting information about your InsightIQ instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No InsightIQ instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    if protocol == 'https':
+        port_number = 443
+    else:
+        port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ip,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/onefs.py
+++ b/vlab_cli/subcommands/portmap/onefs.py
@@ -1,0 +1,55 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to a OneFS node"""
+import ipaddress
+
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address', cls=MandatoryOption,
+              help='Explicitly supply the IP of the OneFS node')
+@click.option('-p', '--protocol', type=click.Choice(['ssh', 'https']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the OneFS node to create a rule for')
+@click.pass_context
+def onefs(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to an OneFS node instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/onefs',
+                        message='Collecting information about your OneFS nodes',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No OneFS node named {} found'.format(name)
+        raise click.ClickException(error)
+
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError as doh:
+        raise click.ClickException(doh)
+    else:
+        ip = ip_address
+
+    if protocol == 'https':
+        port_number = 8080
+    else:
+        port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ip,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/router.py
+++ b/vlab_cli/subcommands/portmap/router.py
@@ -1,0 +1,45 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to a network Router"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the network Router')
+@click.option('-p', '--protocol', type=click.Choice(['ssh']),
+              default='ssh', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the network Router to create a rule for')
+@click.pass_context
+def router(ctx, name, protocol, ip_address):
+    """Create a port mapping rule to a network Router"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/router',
+                        message='Collecting information about your Routers',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No Router named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    port_number = 22
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ip,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/windows.py
+++ b/vlab_cli/subcommands/portmap/windows.py
@@ -1,0 +1,45 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to a Windows Desktop instance"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the Windows Desktop instance')
+@click.option('-p', '--protocol', type=click.Choice(['rdp']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the Windows Desktop instance to create a rule for')
+@click.pass_context
+def windows(ctx, name, protocol):
+    """Create a port mapping rule to a Windows Desktop instance"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/windows',
+                        message='Collecting information about your Windows Desktop instances',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No Windows Desktop instance named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    port_number = 3389
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ips,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/portmap/winserver.py
+++ b/vlab_cli/subcommands/portmap/winserver.py
@@ -1,0 +1,45 @@
+# -*- coding: UTF-8 -*-
+"""Defines the CLI for creating a port mapping rule to a Windows Server"""
+import click
+
+from vlab_cli.lib.api import consume_task
+from vlab_cli.lib.widgets import Spinner, typewriter
+from vlab_cli.lib.click_extras import MandatoryOption, get_portmap_ip
+
+
+@click.command()
+@click.option('-a', '--ip-address',
+              help='Explicitly supply the IP of the Windows Server')
+@click.option('-p', '--protocol', type=click.Choice(['rdp']),
+              default='https', show_default=True,
+              help='The protocol to create a mapping rule for')
+@click.option('-n', '--name', cls=MandatoryOption,
+              help='The name of the Windows Server to create a rule for')
+@click.pass_context
+def winserver(ctx, name, protocol):
+    """Create a port mapping rule to a Windows Server"""
+    info = consume_task(ctx.obj.vlab_api,
+                        endpoint='/api/1/inf/winserver',
+                        message='Collecting information about your Windows Servers',
+                        method='GET').json()
+    if not info['content']:
+        if info['error']:
+            ctx.log.debug('Error in server API response')
+            error = info['error']
+        else:
+            error = 'No Windows Servier named {} found'.format(name)
+        raise click.ClickException(error)
+
+    ips = [x for x in info['content'][name]['ips'] if ":" not in x]
+    ip = get_portmap_ip(ips, ip_address)
+    port_number = 3389
+    with Spinner("Mapping port"):
+        try:
+            ctx.obj.vlab_api.map_port(target_addr=ips,
+                                      target_port=port_number,
+                                      target_name=name,
+                                      target_component=info['content'][name]['meta']['component'])
+        except Exception as doh:
+            ctx.obj.log.debug(doh, exc_info=True)
+            raise click.Exception(doh)
+    typewriter('OK!')

--- a/vlab_cli/subcommands/show/gateway.py
+++ b/vlab_cli/subcommands/show/gateway.py
@@ -11,7 +11,7 @@ from vlab_cli.lib.api import consume_task
 def gateway(ctx):
     """Display information about network lab gateway"""
     resp = consume_task(ctx.obj.vlab_api,
-                        endpoint='/api/1/inf/gateway',
+                        endpoint='/api/2/inf/gateway',
                         message='Looking up your default gateway',
                         method='GET')
     info = resp.json()['content']


### PR DESCRIPTION
This PR updates the CLI so that users can manually make port mapping rules. The next stage is to have the CLI _automatically_ make the rules upon component creation. I don't expect this subcommand to be used much; mostly I see it as a way to enable users to _self help_ when something goes sideways with the automation, or if the user starts manually mucking about with their IPs.