### PR TITLE
Bug windows

### DIFF
--- a/vlab_cli/lib/api.py
+++ b/vlab_cli/lib/api.py
@@ -54,7 +54,6 @@ class vLabApi(object):
     :type log: logging.Logger
     """
     def __init__(self, server, token, verify=False, log=None):
-        self._ipam_ip = None
         self._server = server
         self._session = requests.Session()
         self._header = {'X-Auth': token,

--- a/vlab_cli/lib/connectorizer.py
+++ b/vlab_cli/lib/connectorizer.py
@@ -2,6 +2,10 @@
 """Logic for opening a specific protocol client"""
 import subprocess
 
+import click
+
+from vlab_cli.lib.api import consume_task
+
 
 class Connectorizer(object):
     """Handles opening the specific protocol client with the correct syntax regardless
@@ -10,7 +14,7 @@ class Connectorizer(object):
     :param config: The vLab config file
     :type config: configparser.ConfigParser
     """
-    def __init__(self, config):
+    def __init__(self, config, vlab_api):
         if config['SSH']['agent'] == 'putty':
             self._ssh_str = '%s -ssh {} -P {}' % config['SSH']['location']
         else:
@@ -27,30 +31,50 @@ class Connectorizer(object):
             self._rdp_str = '%s /v:{}:{} /w:1920 /h:1080' % config['RDP']['location']
         else:
             self._rdp_str = '%s --server {}:{}' % config['RDP']['location']
+        self._gateway_ip = self._find_gateway_ip(vlab_api)
 
-    def ssh(self, ip_addr, port):
+    def _find_gateway_ip(self, vlab_api):
+        """Connecting requires knowledge of the user's IPAM gateway address"""
+        resp = consume_task(vlab_api,
+                            endpoint='/api/2/inf/gateway',
+                            message='Looking up gateway IP',
+                            method='GET').json()['content']
+        gateway_ip = None
+        for ip in resp['ips']:
+            if ':' in ip:
+                continue
+            elif ip == '192.168.1.1':
+                continue
+            else:
+                gateway_ip = ip
+                break
+        else:
+            raise click.ClickException("Unable to locate gateway IP from values: {}".format(resp['ips']))
+        return gateway_ip
+
+    def ssh(self, port):
         """Open a session via SSH in a new client"""
-        syntax = self._ssh_str.format(ip_addr, port)
+        syntax = self._ssh_str.format(self._gateway_ip, port)
         subprocess.Popen(syntax.split(' '))
 
-    def https(self, ip_addr, port, url=None):
+    def https(self, port, url=None):
         """Open a session via HTTPS in a new client"""
         if url:
             url = url[8:] # strip of redundant https://
             syntax = self._https_str.format(url, '')
             syntax = syntax[:-1] # strip off tailing :
         else:
-            syntax = self._https_str.format(ip_addr, port)
+            syntax = self._https_str.format(self._gateway_ip, port)
         subprocess.Popen(syntax.split(' '))
 
-    def rdp(self, ip_addr, port):
+    def rdp(self, port):
         """Open a session via RDP in a new client"""
-        syntax = self._rdp_str.format(ip_addr, port)
+        syntax = self._rdp_str.format(self._gateway_ip, port)
         subprocess.Popen(syntax.split(' '))
 
-    def scp(self, ip_addr, port):
+    def scp(self, port):
         """Open a session via SCP in a new client"""
-        syntax = self._scp_str.format(ip_addr, port)
+        syntax = self._scp_str.format(self._gateway_ip, port)
         if self._scp_open:
             subprocess.Popen(syntax.split(' '))
         else:

--- a/vlab_cli/subcommands/connect/cee.py
+++ b/vlab_cli/subcommands/connect/cee.py
@@ -29,5 +29,5 @@ def cee(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
-    conn.rdp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
+    conn.rdp(port=conn_port)

--- a/vlab_cli/subcommands/connect/centos.py
+++ b/vlab_cli/subcommands/connect/centos.py
@@ -29,5 +29,5 @@ def centos(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
-    conn.ssh(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
+    conn.ssh(port=conn_port)

--- a/vlab_cli/subcommands/connect/claritynow.py
+++ b/vlab_cli/subcommands/connect/claritynow.py
@@ -29,15 +29,15 @@ def claritynow(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
     if protocol == 'ssh':
-        conn.ssh(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.ssh(port=conn_port)
     elif protocol == 'https':
-        conn.https(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.https(port=conn_port)
     elif protocol == 'scp':
-        conn.scp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.scp(port=conn_port)
     elif protocol == 'rdp':
-        conn.rdp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.rdp(port=conn_port)
     else:
         error = 'Unexpected protocol requested: {}'.format(protocol)
         raise RuntimeError(error)

--- a/vlab_cli/subcommands/connect/ecs.py
+++ b/vlab_cli/subcommands/connect/ecs.py
@@ -29,13 +29,13 @@ def ecs(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
     if protocol == 'ssh':
-        conn.ssh(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.ssh(port=conn_port)
     elif protocol == 'https':
-        conn.https(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.https(port=conn_port)
     elif protocol == 'scp':
-        conn.scp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.scp(port=conn_port)
     else:
         error = 'Unexpected protocol requested: {}'.format(protocol)
         raise RuntimeError(error)

--- a/vlab_cli/subcommands/connect/esrs.py
+++ b/vlab_cli/subcommands/connect/esrs.py
@@ -29,13 +29,13 @@ def esrs(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
     if protocol == 'ssh':
-        conn.ssh(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.ssh(port=conn_port)
     elif protocol == 'https':
-        conn.https(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.https(port=conn_port)
     elif protocol == 'scp':
-        conn.scp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.scp(port=conn_port)
     else:
         error = 'Unexpected protocol requested: {}'.format(protocol)
         raise RuntimeError(error)

--- a/vlab_cli/subcommands/connect/icap.py
+++ b/vlab_cli/subcommands/connect/icap.py
@@ -29,5 +29,5 @@ def icap(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
-    conn.rdp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
+    conn.rdp(port=conn_port)

--- a/vlab_cli/subcommands/connect/iiq.py
+++ b/vlab_cli/subcommands/connect/iiq.py
@@ -29,13 +29,13 @@ def insightiq(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
     if protocol == 'ssh':
-        conn.ssh(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.ssh(port=conn_port)
     elif protocol == 'https':
-        conn.https(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.https(port=conn_port)
     elif protocol == 'scp':
-        conn.scp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.scp(port=conn_port)
     else:
         error = 'Unexpected protocol requested: {}'.format(protocol)
         raise RuntimeError(error)

--- a/vlab_cli/subcommands/connect/onefs.py
+++ b/vlab_cli/subcommands/connect/onefs.py
@@ -29,13 +29,13 @@ def onefs(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
     if protocol == 'ssh':
-        conn.ssh(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.ssh(port=conn_port)
     elif protocol == 'https':
-        conn.https(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.https(port=conn_port)
     elif protocol == 'scp':
-        conn.scp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+        conn.scp(port=conn_port)
     else:
         error = 'Unexpected protocol requested: {}'.format(protocol)
         raise RuntimeError(error)

--- a/vlab_cli/subcommands/connect/router.py
+++ b/vlab_cli/subcommands/connect/router.py
@@ -26,6 +26,6 @@ def router(ctx, name, protocol):
     if not vm:
         error = 'You have no router named {}'.format(name)
         raise click.ClickException(error)
-    conn = Connectorizer(ctx.obj.vlab_config)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
     url = vm['console']
-    conn.https(ip_addr=None, port=None, url=url)
+    conn.https(port=None, url=url)

--- a/vlab_cli/subcommands/connect/windows.py
+++ b/vlab_cli/subcommands/connect/windows.py
@@ -29,5 +29,5 @@ def windows(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
-    conn.rdp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
+    conn.rdp(port=conn_port)

--- a/vlab_cli/subcommands/connect/winserver.py
+++ b/vlab_cli/subcommands/connect/winserver.py
@@ -29,5 +29,5 @@ def winserver(ctx, name, protocol):
         error = 'No mapping rule for {} to {} exists'.format(protocol, name)
         raise click.ClickException(error)
 
-    conn = Connectorizer(ctx.obj.vlab_config)
-    conn.rdp(ip_addr=ctx.obj.vlab_api._ipam_ip, port=conn_port)
+    conn = Connectorizer(ctx.obj.vlab_config, ctx.obj.vlab_api)
+    conn.rdp(port=conn_port)

--- a/vlab_cli/subcommands/token.py
+++ b/vlab_cli/subcommands/token.py
@@ -50,8 +50,8 @@ def handle_show(token_contents):
     Client IP  : {}
     """.format(token_contents['username'],
                token_contents['iss'],
-               time.strftime('%m/%d/%Y %H:%M:%s', time.gmtime(token_contents['iat'])),
-               time.strftime('%m/%d/%Y %H:%M:%s', time.gmtime(token_contents['exp'])),
+               time.strftime('%m/%d/%Y %H:%M', time.gmtime(token_contents['iat'])),
+               time.strftime('%m/%d/%Y %H:%M', time.gmtime(token_contents['exp'])),
                token_contents['version'],
                token_contents['client_ip'])
     click.echo(textwrap.dedent(info))


### PR DESCRIPTION
Fixed two things:

1) The command `vlab token --show` would generate a trackeback
```
PS C:\Users\willhn> vlab token --show
Traceback (most recent call last):
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\cx_Freeze\initscripts\__startup__.py", line 14, in run
    module.run()
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\cx_Freeze\initscripts\Console.py", line 26, in run
    exec(code, m.__dict__)
  File "vlab", line 10, in <module>
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "C:\Users\willhn\AppData\Local\Programs\Python\Python36\lib\site-packages\click\decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "C:\Users\willhn\code\vlab_cli\vlab_cli\subcommands\token.py", line 21, in token
    handle_show(ctx.obj.token_contents)
  File "C:\Users\willhn\code\vlab_cli\vlab_cli\subcommands\token.py", line 53, in handle_show
    time.strftime('%m/%d/%Y %H:%M:%s', time.gmtime(token_contents['iat'])),
ValueError: Invalid format string
```

2) Forgot to fix the `vlab connect` logic when pulling out the IPAM business logic